### PR TITLE
fix client unsubscribe channel

### DIFF
--- a/internal/app/api/client.go
+++ b/internal/app/api/client.go
@@ -365,8 +365,8 @@ func (c *Client) Unsubscribe(ID string, channels []string) (bool, error) {
 		return false, err
 	}
 
-	for i, channel := range channels {
-		if validator.IsIn(channel, clientResult.Channels) {
+	for i, channel := range clientResult.Channels {
+		if validator.IsIn(channel, channels) {
 			ok, err := c.RemoveFromChannel(ID, channel)
 			if !ok || err != nil {
 				return false, err


### PR DESCRIPTION
Here is the info of client `7a3d37c0-9706-4570-add0-2a9c41ab251a` after subscribing to 4 channels
```
curl -X GET \
    -H 'Content-Type: application/json' \
    -H 'X-AUTH-TOKEN: sWUhHRcs4Aqa0MEnYwbuQln3EW8CZ0oD' \
    -d '' \
    'http://localhost:8080/api/client/7a3d37c0-9706-4570-add0-2a9c41ab251a'
{"channels":["app_x_chatroom_1","app_x_chatroom_2","app_x_chatroom_3","app_x_chatroom_4"],"created_at":1582012347,"id":"7a3d37c0-9706-4570-add0-2a9c41ab251a","token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjoiN2EzZDM3YzAtOTcwNi00NTcwLWFkZDAtMmE5YzQxYWIyNTFhQDE1ODIwMTIzNDciLCJ0aW1lc3RhbXAiOjE1ODIwMTIzNDd9.6KYv9wLEoLhUxsdYutO1czzRsWamWu5OWlXS1Yobr78","updated_at":1582012347}
```

then unsubscribe channel `app_x_chatroom_2`
```
curl -X PUT \
    -H 'Content-Type: application/json' \
    -H 'X-AUTH-TOKEN: sWUhHRcs4Aqa0MEnYwbuQln3EW8CZ0oD' \
    -d '{"channels": ["app_x_chatroom_2"]}' \
    'http://localhost:8080/api/client/7a3d37c0-9706-4570-add0-2a9c41ab251a/unsubscribe'
```

get the info again
```
curl -X GET \
    -H 'Content-Type: application/json' \
    -H 'X-AUTH-TOKEN: sWUhHRcs4Aqa0MEnYwbuQln3EW8CZ0oD' \
    -d '' \
    'http://localhost:8080/api/client/7a3d37c0-9706-4570-add0-2a9c41ab251a'
{"channels":["app_x_chatroom_4","app_x_chatroom_2","app_x_chatroom_3"],"created_at":1582012347,"id":"7a3d37c0-9706-4570-add0-2a9c41ab251a","token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjoiN2EzZDM3YzAtOTcwNi00NTcwLWFkZDAtMmE5YzQxYWIyNTFhQDE1ODIwMTIzNDciLCJ0aW1lc3RhbXAiOjE1ODIwMTIzNDd9.6KYv9wLEoLhUxsdYutO1czzRsWamWu5OWlXS1Yobr78","updated_at":1582012347}
```
channel `app_x_chat_room_1` is removed unexpectedly, while `app_x_chatroom_2` is still in the channel list
