### PR TITLE
shrink binary size, optimize dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+.git
+.github
+assets
+var/logs
+*.md
+LICENSE
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Config file
+config.dist.yml
+
+# App build
+beaver
+
+# Ignore vendor and run dep ensure
+vendor
+
+config.test.yml
+coverage.html
+cover.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,25 +4,22 @@ ENV GO111MODULE=on
 
 ARG BEAVER_VERSION=1.2.2
 
-RUN mkdir -p $GOPATH/src/github.com/clivern
-
-RUN git clone -b master https://github.com/Clivern/Beaver.git $GOPATH/src/github.com/clivern/beaver
-
 WORKDIR $GOPATH/src/github.com/clivern/beaver
+
+ADD . .
 
 RUN git checkout tags/$BEAVER_VERSION
 
 RUN go mod download
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/beaver .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -a -installsuffix cgo -o /go/bin/beaver .
 
-RUN mkdir -p /go/logs/beaver
-RUN mkdir -p /go/configs/beaver
+RUN mkdir -p /go/logs/beaver && mkdir -p /go/configs/beaver
 
 # Build a small image
 FROM alpine:3.12
-RUN apk --no-cache add ca-certificates
+RUN  apk --no-cache add ca-certificates
 
 # Copy our static executable
 COPY --from=builder /go/bin/beaver /go/bin/beaver

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ coverage:
 ## build: Build the application.
 build:
 	rm -f beaver
-	$(GO) build -o beaver beaver.go
+	$(GO) build -ldflags="-s -w" -o beaver beaver.go
 
 
 ## ci: Run all CI tests.


### PR DESCRIPTION
Hi Clivern:
just few optimization
1. we can use [`-s` and `-w` linker flags](https://golang.org/cmd/link/)  to strip the debugging info, we don't need these in our executable file,  and this can make our binary executable file smaller,  to prove this, I do it on windows10 and using git-bash

- without `-ldflags="-s -w"`
```sh
/d/golang/src/github.com/Clivern/Beaver (master)
$ make build
rm -f beaver
go build -o beaver beaver.go
$ du -sh beaver
13M     beaver
```
   
- with `-ldflags="-s -w"`
```sh
/d/golang/src/github.com/Clivern/Beaver (master)
$ make build
rm -f beaver
go build -ldflags="-s -w" -o beaver beaver.go

$ du -sh beaver
9.2M    beaver
```
and we save **3.8MB** disk space, and I add this to Dockerfile

2. optimize Dockerfile

-  as the [docker documentation](https://docs.docker.com/engine/reference/builder/#workdir) says: If the WORKDIR doesn’t exist, it will be created, so we can just use `$GOPATH/src/github.com/clivern/beaver`  without mkdir first.
-  since a developer has already clone this repository, there is no need to add `git clone https://github.com/Clivern/Beaver.git` in the dockerfile, just COPY current directory to the container, this is much faster than clone from network. and type `docker build -t clivern/beaver:v0.x` will make the image.  
- I don't know why you checkout to the specified TAG, so I leave the line as before. but, if HEAD of this git repository is not the specified TAG, the newest source code will not be built into the image.
-  in Dockerfile, two mkdir commands can be merge to one, this can [minimize the number of layers](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers)
- to speed up build speed, I added a .dockerignore file

IMPORTANT:
BECAUSE MY COMPANY NETWORK HAS BLOCK DOCKER REGISTRY, SO I'M NOT SURE WEATHER THIS DOCKERFILE WILL WORK OR NOT
AFTER I GO HOME, I WILL TEST IT, SO YOU MAY REFUSE TO MERGE IT NOW.
  













