### PR TITLE
refactor: replaced `bytes.NewBuffer` with `bytes.NewBufferString`

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -51,7 +51,7 @@ var towerCmd = &cobra.Command{
 		}
 
 		viper.SetConfigType("yaml")
-		err = viper.ReadConfig(bytes.NewBuffer([]byte(configParsed)))
+		err = viper.ReadConfig(bytes.NewBufferString(configParsed))
 
 		if err != nil {
 			panic(fmt.Sprintf(


### PR DESCRIPTION
This PR change one function of bytes package with a similar one, as result code
produce less allocations on heap.